### PR TITLE
fix: update base64 image regex

### DIFF
--- a/lib/third-party-fix.js
+++ b/lib/third-party-fix.js
@@ -1,10 +1,10 @@
 window.addEventListener('load', function(){
   var imgRegex = /\.(gif|jpg|jpeg|tiff|png)$/i;
-  var base64ImgRegex = /^data:image\/[a-z]+;base64,/;
+  var base64ImgRegex = /^data:image\/[a-z\d\-\.\+]+;base64,/;
   var images = Array.prototype.slice.call(document.querySelectorAll('img[data-original]'));
   images.forEach(function(img) {
     var parentNode = img.parentNode;
-    if(parentNode.tagName === 'A' && (parentNode.href.match(imgRegex) || parentNode.href.match(base64ImgRegex))) {
+    if(parentNode.tagName === 'A' && (imgRegex.test(parentNode.href) || base64ImgRegex.test(parentNode.href))) {
       parentNode.href = img.dataset.original;
     }
   });


### PR DESCRIPTION
This commit contains following changes in `lib/third-party-fix.js`:
1. update `base64ImgRegex` to match image MIME types. As in [NPM package source code](https://www.npmjs.com/package/hexo-lazyload-image?activeTab=code), default imge is `data:image/svg+xml;base64,P` which original regex doesn't match;
2. use `imgRegex.test(parentNode.href)` to get a boolean result in if condition.